### PR TITLE
Added gitattributes to set line endings for windows build support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*        text=auto
+*.sh     text  eol=lf


### PR DESCRIPTION
mdenet/educationplatform#64, adding to all repositories so future commits are normalised properly across all platforms developers are using.