### PR TITLE
Moved common utilities into the educationplatform static

### DIFF
--- a/consoles/consoles_activity.json
+++ b/consoles/consoles_activity.json
@@ -9,7 +9,7 @@
 
             "icon": "console",
 
-            "tools": [ "http://127.0.0.1:8081/epsilon/epsilon_tool.json"],
+            "tools": [ ],
 
             "layout": {
 
@@ -58,7 +58,7 @@
 
             "icon": "console",
 
-            "tools": [ "http://127.0.0.1:8081/epsilon/epsilon_tool.json"],
+            "tools": [ ],
 
             "layout": {
 
@@ -119,7 +119,7 @@
 
             "icon": "console",
 
-            "tools": [ "http://127.0.0.1:8081/epsilon/epsilon_tool.json"],
+            "tools": [ ],
 
             "layout": {
 
@@ -191,7 +191,7 @@
 
             "icon": "console",
 
-            "tools": [ "http://127.0.0.1:8081/epsilon/epsilon_tool.json"],
+            "tools": [ ],
 
             "layout": {
 
@@ -271,7 +271,7 @@
 
             "icon": "console",
 
-            "tools": [ "http://127.0.0.1:8081/epsilon/epsilon_tool.json"],
+            "tools": [ ],
 
             "layout": {
 

--- a/conversion-functions/emfatic-conversion_activity.json
+++ b/conversion-functions/emfatic-conversion_activity.json
@@ -10,9 +10,9 @@
 
             "icon": "refresh",
 
-            "tools": [ "http://127.0.0.1:8081/emf/emf_tool.json", 
-                       "http://127.0.0.1:8081/emfatic/emfatic_tool.json", 
-                       "http://127.0.0.1:8081/epsilon/epsilon_tool.json"],
+            "tools": [ "http://127.0.0.1:8073/emf_tool.json", 
+                       "http://127.0.0.1:8071/emfatic_tool.json"
+                     ],
 
             "layout": {
 

--- a/epsilon-etl/epsilon-etl_activity.json
+++ b/epsilon-etl/epsilon-etl_activity.json
@@ -10,17 +10,14 @@
 
             "icon": "etl",
 
-            "tools": [ "http://127.0.0.1:8081/epsilon/epsilon_tool.json",
-                       "http://127.0.0.1:8081/emfatic/emfatic_tool.json" ],
+            "tools": [ "http://127.0.0.1:8070/epsilon_tool.json",
+                       "http://127.0.0.1:8071/emfatic_tool.json" ],
 
             "layout": {
 
                     "area": [
-
-                        ["panel-eol",     "panel-model"],
-
-                        ["panel-console", "panel-mm"]
-
+                        ["panel-etl",   "panel-smodel", "panel-tmodel"],
+                        ["panel-console", "panel-smm",  "panel-tmm"]
                     ]
 
                 },

--- a/ocl/ocl_activity.json
+++ b/ocl/ocl_activity.json
@@ -12,8 +12,7 @@
 
             "tools": ["http://127.0.0.1:8072/ocl_tool.yml",
                        "http://127.0.0.1:8070/epsilon_tool.json",
-                       "http://127.0.0.1:8071/emfatic_tool.json",
-                       "http://127.0.0.1:8073/emf_tool.json" ],
+                       "http://127.0.0.1:8071/emfatic_tool.json"],
 
             "layout": {
 

--- a/xtext-turtles/xtext_activity.json
+++ b/xtext-turtles/xtext_activity.json
@@ -10,8 +10,7 @@
 
             "icon": "xtext",
 
-            "tools": [ "http://127.0.0.1:8070/epsilon_tool.json",
-                        "http://127.0.0.1:8074/xtext_tool.json"],
+            "tools": ["http://127.0.0.1:8074/xtext_tool.json"],
 
             "layout": {
 


### PR DESCRIPTION
Moved common utilities into the educationplatform static to help with deployment and tidy up.
 
Updated examples included tools after moving common utilities into the educationplatform static.