### PR TITLE
Turtles example removed unused attributes from the activity config

### DIFF
--- a/xtext-turtles/xtext_activity.json
+++ b/xtext-turtles/xtext_activity.json
@@ -52,16 +52,6 @@
                     "ref": "xtext-grammar",
     
                     "file": "uk.kcl.inf.mdd1.turtles.parent/uk.kcl.inf.mdd1.turtles/src/uk/kcl/inf/mdd1/Turtles.xtext",
-    
-                    "languageName": "uk.kcl.inf.mdd1.turtles.Turtles",
-
-                    "baseName": "uk.kcl.inf.mdd1.turtles",
-
-                    "extension": "turtles",
-
-                    "projectFiles" : [  
-
-                    ],
 
                     "editorPanel": "panel-turtles",
                     


### PR DESCRIPTION
Turtles example removed unused attributes from the activity configuration file.

Noticed duplicated attributes during practice for training for teachers, raised issue mdenet/educationplatform#92 for moving the attributes that specify the output location of a language workbench editor instance to be under actions. 

Support for projectFiles recorded under mdenet/educationplatform#81 features to add.