### PR TITLE
Switch to using the epsilon micronaught service

### DIFF
--- a/epsilon-etl/epsilon-etl_activity.json
+++ b/epsilon-etl/epsilon-etl_activity.json
@@ -10,7 +10,7 @@
 
             "icon": "etl",
 
-            "tools": [ "http://127.0.0.1:8070/epsilon_tool.json",
+            "tools": [ "http://127.0.0.1:8070/tools",
                        "http://127.0.0.1:8071/emfatic_tool.json" ],
 
             "layout": {

--- a/epsilon-example/epsilon-example_activity.json
+++ b/epsilon-example/epsilon-example_activity.json
@@ -10,7 +10,7 @@
 
             "icon": "evl",
 
-            "tools": [ "http://127.0.0.1:8070/epsilon_tool.json",
+            "tools": [ "http://127.0.0.1:8070/tools",
                        "http://127.0.0.1:8071/emfatic_tool.json"],
 
             "layout": {
@@ -108,7 +108,7 @@
 
             "icon": "evl",
 
-            "tools": [ "http://127.0.0.1:8070/epsilon_tool.json"],
+            "tools": [ "http://127.0.0.1:8070/tools"],
 
             "layout": {
 
@@ -208,7 +208,7 @@
 
         "icon": "etl",
 
-        "tools": [ "http://127.0.0.1:8070/epsilon_tool.json"],
+        "tools": [ "http://127.0.0.1:8070/tools"],
 
         "layout": {
 

--- a/epsilon-example/epsilon-example_activity.yml
+++ b/epsilon-example/epsilon-example_activity.yml
@@ -33,7 +33,7 @@ activities:
     ref: console
   title: Query Project Plan
   tools:
-  - http://127.0.0.1:8070/epsilon_tool.json
+  - http://127.0.0.1:8070/tools
   - http://127.0.0.1:8071/emfatic_tool.json
 - actions:
   - output: panel-problems
@@ -74,7 +74,7 @@ activities:
     ref: problem
   title: Validate Project Plan
   tools:
-  - http://127.0.0.1:8070/epsilon_tool.json
+  - http://127.0.0.1:8070/tools
 - actions:
   - output: panel-tmodel
     parameters:
@@ -119,5 +119,5 @@ activities:
     ref: console
   title: Transform to Deliverables
   tools:
-  - http://127.0.0.1:8070/epsilon_tool.json
+  - http://127.0.0.1:8070/tools
 

--- a/ocl/ocl_activity.json
+++ b/ocl/ocl_activity.json
@@ -11,7 +11,7 @@
             "icon": "ocl",
 
             "tools": ["http://127.0.0.1:8072/ocl_tool.yml",
-                       "http://127.0.0.1:8070/epsilon_tool.json",
+                       "http://127.0.0.1:8070/tools",
                        "http://127.0.0.1:8071/emfatic_tool.json"],
 
             "layout": {

--- a/ocl/ocl_activity.json
+++ b/ocl/ocl_activity.json
@@ -12,7 +12,8 @@
 
             "tools": ["http://127.0.0.1:8072/ocl_tool.yml",
                        "http://127.0.0.1:8070/tools",
-                       "http://127.0.0.1:8071/emfatic_tool.json"],
+                       "http://127.0.0.1:8071/emfatic_tool.json",
+                       "http://127.0.0.1:8069/conversion_tool.json"],
 
             "layout": {
 

--- a/xtext-turtles/xtext_activity.json
+++ b/xtext-turtles/xtext_activity.json
@@ -81,7 +81,7 @@
 
             "icon": "xtext",
 
-            "tools": [ "http://127.0.0.1:8070/epsilon_tool.json",
+            "tools": [ "http://127.0.0.1:8070/tools",
                         "http://127.0.0.1:8074/xtext_tool.json"],
 
             "layout": {


### PR DESCRIPTION
For mdenet/platformtools#32, updated the activity tool urls after switching to use the Epsilon micronaught service. 

PR mdenet/platformtools#33 and  PR mdenet/educationplatform-docker#43 should be completed and merged before this. 