### PR TITLE
Corrected turtles example paths

### DIFF
--- a/xtext-turtles/xtext_activity.json
+++ b/xtext-turtles/xtext_activity.json
@@ -29,8 +29,8 @@
                     "sourceButton": "action-button",
 
                     "parameters": {
-                        "languageName": "uk.ac.kcl.inf.mdd1.turtles.Turtles",
-                        "baseName": "uk.ac.kcl.inf.mdd1.turtles",
+                        "languageName": "uk.kcl.inf.mdd1.Turtles",
+                        "baseName": "uk.kcl.inf.mdd1.turtles",
                         "extension": "turtles",
                         "grammar": "panel-xtext"                        
                     },


### PR DESCRIPTION
Corrected turtles example paths to correspond to the names used in the project. The Xtext project is missing the `.ac` part of the package name. An alternative fix would be to recreate the Xtext project to include the missing `.ac` package path.

All activities that are based off of this Xtext activity need to be updated when applying mdenet/platformtools#56