### PR TITLE
URL placeholders quoted.

### DIFF
--- a/epsilon-example/epsilon-example_activity.yml
+++ b/epsilon-example/epsilon-example_activity.yml
@@ -33,8 +33,8 @@ activities:
     ref: console
   title: Query Project Plan
   tools:
-  - {{BASE-URL}}:8070/tools
-  - {{BASE-URL}}:8071/emfatic_tool.json
+  - "{{BASE-URL}}:8070/tools"
+  - "{{BASE-URL}}:8071/emfatic_tool.json"
 - actions:
   - output: panel-problems
     parameters:
@@ -74,7 +74,7 @@ activities:
     ref: problem
   title: Validate Project Plan
   tools:
-  - {{BASE-URL}}:8070/tools
+  - "{{BASE-URL}}:8070/tools"
 - actions:
   - output: panel-tmodel
     parameters:
@@ -119,5 +119,5 @@ activities:
     ref: console
   title: Transform to Deliverables
   tools:
-  - {{BASE-URL}}:8070/tools
+  - "{{BASE-URL}}:8070/tools"
 


### PR DESCRIPTION
Fix for #15 , URL placeholders in the Epsilon YAML config have been enclosed with quotation marks. 